### PR TITLE
bump version of ws from 0.4.14 -> 0.4.20 to support node 0.8+

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "coffee-script": "1.3.3",
-    "ws" : "0.4.20"
+    "ws": "0.4.20"
   },
   "devDependencies": {
     "mocha": "1.2.2",


### PR DESCRIPTION
Was getting this error:

  npm ERR! notsup Not compatible with your version of node/npm: commander@0.5.2
  npm ERR! notsup Required: {"node":">= 0.4.x < 0.8.0"}
  npm ERR! notsup Actual: {"npm":"1.1.32","node":"0.8.0"}

Reason: ws 0.4.14 depended on commander 0.5.2 which had node dependency of `{"node":">= 0.4.x < 0.8.0"}`. See https://github.com/visionmedia/commander.js/issues/66

ws 0.4.20 works fine for me on node 0.8 (osx/lion); tests passed
