### PR TITLE
Add bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,8 @@
+{
+  "name": "auto-reload-brunch",
+  "version": "1.6.2",
+  "description": "Adds automatic browser reloading support to brunch.",
+  "main": "vendor/auto-reload.js",
+  "dependencies": {
+  }
+}

--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,11 @@
   "version": "1.6.2",
   "description": "Adds automatic browser reloading support to brunch.",
   "main": "vendor/auto-reload.js",
+  "ignore": [
+    "lib",
+    "src",
+    "test"
+  ],
   "dependencies": {
   }
 }

--- a/component.json
+++ b/component.json
@@ -3,6 +3,11 @@
   "version": "1.6.2",
   "description": "Adds automatic browser reloading support to brunch.",
   "main": "vendor/auto-reload.js",
+  "ignore": [
+    "lib",
+    "src",
+    "test"
+  ],
   "dependencies": {
   },
   "scripts": [

--- a/component.json
+++ b/component.json
@@ -1,0 +1,11 @@
+{
+  "name": "auto-reload-brunch",
+  "version": "1.6.2",
+  "description": "Adds automatic browser reloading support to brunch.",
+  "main": "vendor/auto-reload.js",
+  "dependencies": {
+  },
+  "scripts": [
+    "vendor/auto-reload.js"
+  ]
+}

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,11 @@
       "homepage": "http://paulmillr.com/"
     }
   ],
+  "ignore": [
+    "lib",
+    "src",
+    "test"
+  ],
   "require": {
       "robloach/component-installer": "*"
   },

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,27 @@
+{
+  "name": "auto-reload-brunch",
+  "version": "1.6.2",
+  "type": "component",
+  "keywords": [
+    "JavaScript",
+    "brunch"
+  ],
+  "homepage": "https://github.com/brunch/auto-reload-brunch",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Paul Miller",
+      "homepage": "http://paulmillr.com/"
+    }
+  ],
+  "require": {
+      "robloach/component-installer": "*"
+  },
+  "extra": {
+    "component": {
+      "scripts": [
+        "vendor/auto-reload.js"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
used to register the package with bower:
`bower register auto-reload-brunch git://github.com/brunch/auto-reload-brunch.git`

now it's possible to:
`bower install auto-reload-brunch`
and have it automatically compiled by brunch, e.g. in config.coffee/files.javascripts.joinTo:

``` coffee
        'js/vendor-develop.js': /// # additional vendor lib for development
          ^vendor.*[\\/](
              'auto-reload'
            )\.js$
          ///
```
