### PR TITLE
Don't reload if autoreload='false' attr is set on stylesheet link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Or, do manual install:
 ## Usage
 In most cases, auto-reload-brunch works out of the box without any further
 configuration. Stylesheet changes will be applied seamlessly, and any other
-changes will trigger a page refresh.
+changes will trigger a page refresh. To prevent a stylesheet from being reloaded
+automatically, set the ```data-autoreload="false"``` attribute on the stylesheet's
+link tag.
 
 ### Brunch plugin settings
 If customization is needed or desired, settings can be modified in your brunch
@@ -41,7 +43,9 @@ config file (such as `brunch-config.coffee`):
       tries to reload immediately after a compile, use this to set a delay
       before the reload signal is sent.
 * __host__: (Default: '0.0.0.0') Server's host address.
-* __forceRepaint__: (Default: false) forcefully repaint the page after stylesheets refresh. Enabled in Chrome by default to mitigate the issue when it doesn't always update styles.
+* __forceRepaint__: (Default: false) forcefully repaint the page after stylesheets
+      refresh. Enabled in Chrome by default to mitigate the issue when it doesn't
+      always update styles.
 
 **Example:**
 ```coffeescript

--- a/vendor/auto-reload.js
+++ b/vendor/auto-reload.js
@@ -20,7 +20,7 @@
 
     stylesheet: function(){
       [].slice
-        .call(document.querySelectorAll('link[rel="stylesheet"][href]:not([autoreload="false"]'))
+        .call(document.querySelectorAll('link[rel="stylesheet"][href]:not([data-autoreload="false"]'))
         .forEach(function(link) {
           link.href = cacheBuster(link.href);
         });

--- a/vendor/auto-reload.js
+++ b/vendor/auto-reload.js
@@ -20,7 +20,7 @@
 
     stylesheet: function(){
       [].slice
-        .call(document.querySelectorAll('link[rel="stylesheet"][href]'))
+        .call(document.querySelectorAll('link[rel="stylesheet"][href]:not([autoreload="false"]'))
         .forEach(function(link) {
           link.href = cacheBuster(link.href);
         });


### PR DESCRIPTION
This allows you to prevent certain stylesheets from reloading when a local stylesheet is changed.

Use like this:

```javascript
  <link href='//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css' rel='stylesheet' type='text/css' autoreload='false'>
  <link href='/stylesheets/vendor.css' rel='stylesheet' type='text/css'>
  <link href='/stylesheets/app.css' rel='stylesheet' type='text/css'>
```
