### PR TITLE
Fix issue #57

### DIFF
--- a/vendor/auto-reload.js
+++ b/vendor/auto-reload.js
@@ -1,3 +1,4 @@
+/* jshint ignore:start */
 (function() {
   var WebSocket = window.WebSocket || window.MozWebSocket;
   var br = window.brunch = (window.brunch || {});
@@ -53,3 +54,4 @@
   };
   connect();
 })();
+/* jshint ignore:end */


### PR DESCRIPTION
Fix https://github.com/brunch/auto-reload-brunch/issues/57 where the vendor/auto-reload.js
 was causing JSHint to fail. Fix excludes the entire file from JSHint rather than make it JSHint compliant (this may cause issues with other people's JSHint config).