### PR TITLE
Add a changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# auto-reload-brunch `<unreleased>`
+* Introduce experimental live JS reload functionality. See README for more details and caveats.
+
 # auto-reload-brunch 2.0.0 (Jan 29, 2016)
 * Updated source code & API. The plugin would now only work with Brunch 2.2 and higher.
 


### PR DESCRIPTION
`<unreleased>` in the changelog will need to be updated.

Also after the Brunch release (with CJS bumped to 0.4.1), auto-reload's README needs to be updated to expect this version in live JS reload section.