### PR TITLE
Fix to default cfg.match settings

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,8 +31,8 @@ class AutoReloader {
     }
     this.liveJs = cfg.liveJs;
     this.delay = cfg.delay;
-    this.cssMatch = cfg.match && cfg.match.stylesheets || '*.css';
-    this.jsMatch = cfg.match && cfg.match.javascripts || '*.js';
+    this.cssMatch = cfg.match && cfg.match.stylesheets || /.css$/;
+    this.jsMatch = cfg.match && cfg.match.javascripts || /.js$/;
 
     this.connections = [];
     this.port = this.ports.shift();

--- a/test/index.js
+++ b/test/index.js
@@ -56,7 +56,7 @@ describe('Plugin', function() {
       var messages = [];
       var plugin = this.subject();
       plugin.connections = [ mockConnection(msg => messages.push(msg)) ];
-      plugin.onCompile([ { path: 'abc.css' } ]);
+      plugin.onCompile([ { path: 'public/abc.css' } ]);
       expect(messages).to.eql([ 'stylesheet' ]);
     });
 
@@ -64,7 +64,7 @@ describe('Plugin', function() {
       var messages = [];
       var plugin = this.subject({ liveJs: true });
       plugin.connections = [ mockConnection(msg => messages.push(msg)) ];
-      plugin.onCompile([ { path: 'abc.js' } ]);
+      plugin.onCompile([ { path: 'public/abc.js' } ]);
       expect(messages).to.eql([ 'javascript', 'stylesheet' ]);
     });
 
@@ -72,23 +72,23 @@ describe('Plugin', function() {
       var messages = [];
       var plugin = this.subject();
       plugin.connections = [ mockConnection(msg => messages.push(msg)) ];
-      plugin.onCompile([ { path: 'abc.xyz' } ]);
+      plugin.onCompile([ { path: 'public/abc.xyz' } ]);
       expect(messages).to.eql([ 'page' ]);
     });
 
     it('honors match.stylesheets', function() {
       var messages = [];
-      var plugin = this.subject({ match: { stylesheets: '*.scss' } });
+      var plugin = this.subject({ match: { stylesheets: /.scss$/ } });
       plugin.connections = [ mockConnection(msg => messages.push(msg)) ];
-      plugin.onCompile([ { path: 'abc.scss' } ]);
+      plugin.onCompile([ { path: 'public/abc.scss' } ]);
       expect(messages).to.eql([ 'stylesheet' ]);
     });
 
     it('honors match.javascripts', function() {
       var messages = [];
-      var plugin = this.subject({ match: { javascripts: '*.jsx' }, liveJs: true });
+      var plugin = this.subject({ match: { javascripts: /.jsx$/ }, liveJs: true });
       plugin.connections = [ mockConnection(msg => messages.push(msg)) ];
-      plugin.onCompile([ { path: 'abc.jsx' } ]);
+      plugin.onCompile([ { path: 'public/abc.jsx' } ]);
       expect(messages).to.eql([ 'javascript', 'stylesheet' ]);
     });
 


### PR DESCRIPTION
A recent change to how CSS and JS files are detected for live injection has broken the behavior for probably most projects. This is specifically in relation to PR #67 and commit 8239eb9. The files being matched are output files, which in a default brunch project will be `public/app.css`. However, the default glob `*.css` will fail to match against this pattern due to the directory in the path.

    > anymatch('*.css', 'public/app.css')
    false

Due to this, all CSS changes are causing a full page reload instead of injection, which is by far the coolest features of this module.

I can think of two ways to revert the behavior to match the old behavior of `sysPath.extname(file.path) === '.css'`:

1. directory matching glob: `**/*.css`
2. Regex: `/.css$/`

I did a comparison of the two, and regex is faster, so I went with that for this PR.

    $ node bench.js 
    regex x 703,544 ops/sec ±2.97% (67 runs sampled)
    glob x 533,130 ops/sec ±3.79% (66 runs sampled)
    Fastest is regex

For now a workaround is to add this to your brunch-config.js:

```js
  plugins: {
    autoReload: {
      match: {
        stylesheets: /.css$/,
        javascripts: /.js$/
      }
    }
  }
```

I also updated the tests to more reflect a typical path for the module.

Thanks,
Nate