### PR TITLE
Update ws dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "url": "git@github.com:brunch/auto-reload-brunch.git"
   },
   "scripts": {
-    "test": "node_modules/.bin/eslint index.js && node_modules/.bin/mocha test"
+    "test": "eslint index.js && mocha test"
   },
   "dependencies": {
     "anymatch": "1.3.0",
-    "ws": "~0.8.0"
+    "ws": "~1.1.0"
   },
   "devDependencies": {
     "mocha": "1.11.0",


### PR DESCRIPTION
If possible it would be nice to have this plugin updated to use `ws` version ~1.1.0. Aside from the security fix which probably isn't a huge deal for a dev tool, they've removed the dependency on a couple of native binary packages which caused a lot of noise when installing. Even though they were "optional" before, they still caused warnings which lead a bunch of people at my company (running Windows) to think they needed to install a number of different things like Python and C++ tools.

Needless to say it didn't help my Brunch evangelism.

I've also tested this in a couple of my applications, and all is well.