### PR TITLE
only replace wss with wss if the compiled script is "auto-reload.js"

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,8 @@ class AutoReloader {
         sysPath.basename(params.path) === fileName) {
       finalData = finalData.replace(startingPort, this.port);
     }
-    if (this.enabled && this.ssl) {
+    if (this.enabled && this.ssl &&
+        sysPath.basename(params.path) === fileName) {
       finalData = finalData.replace('ws://', 'wss://');
     }
 


### PR DESCRIPTION
I noticed that all injected scripts will have the replace done, as no test is made for the filename (which is actually checked for in the line above