### PR TITLE
Option to allow client to always use wss:// instead of ws://

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ config file (such as `brunch-config.coffee`):
   * Path to private key used for SSL.
 * __certPath__: Optional, no default.
   * Path to public x509 certificate.
+* __forcewss__: Optional, no default.
+  * make the client always use `wss://` instead of `ws://`.
 
 **Example:**
 ```coffeescript
@@ -66,6 +68,7 @@ exports.config =
       delay: 200 if require('os').platform() is 'win32'
       keyPath: 'path/to/ssl.key'
       certPath: 'path/to/ssl.crt'
+      forcewss: true
 ```
 
 ### Client-side settings

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ class AutoReloader {
     this.delay = cfg.delay;
     this.cssMatch = cfg.match && cfg.match.stylesheets || /.css$/;
     this.jsMatch = cfg.match && cfg.match.javascripts || /.js$/;
+    this.forcewss = !!(config.plugins.autoReload.forcewss);
 
     this.connections = [];
     this.port = this.ports.shift();
@@ -135,7 +136,7 @@ class AutoReloader {
         sysPath.basename(params.path) === fileName) {
       finalData = finalData.replace(startingPort, this.port);
     }
-    if (this.enabled && this.ssl &&
+    if (this.enabled && (this.forcewss || this.ssl) &&
         sysPath.basename(params.path) === fileName) {
       finalData = finalData.replace('ws://', 'wss://');
     }

--- a/vendor/auto-reload.js
+++ b/vendor/auto-reload.js
@@ -63,7 +63,7 @@
     }
   };
   var port = ar.port || 9485;
-  var host = br.server || window.location.hostname || 'localhost';
+  var host = ar.host || br.server || window.location.hostname || 'localhost';
 
   var connect = function(){
     var connection = new WebSocket('ws://' + host + ':' + port);


### PR DESCRIPTION
Added a new config option __forcewss__ that ensures the client will use secure websockets (wss) even if the brunch server has started with http.

This is to enable websocket communication with a brunch server running behind an https nginx proxy
