### PR TITLE
Fixes Multi-Socket Reload Bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ class AutoReloader {
     }
     this.server.on('connection', conn => {
       conns.push(conn);
-      conn.on('close', () => conns.splice(conn, 1));
+      conn.on('close', () => conns.splice(conns.indexOf(conn), 1));
     });
     this.server.on('error', error => {
       if (error.toString().match(/EADDRINUSE/)) {


### PR DESCRIPTION
The socket close event handler appears to have a bug in it. As far as I know, the only acceptable first parameter to `Array::splice` is a Number (as opposed to an object as seen in [line 65 of index.js.)](https://github.com/brunch/auto-reload-brunch/blob/673350f86ea4c28efd2a9379e03ca6e24c25a5f1/index.js#L65)

Specifying an object as the first parameter appears to always splice the first element off. This pull request fixes this issue by using `Array::indexOf` to look up the index of the socket first.

Some steps to illustrate this bug:

1. Start your brunch server.
2. Load up the page in Chrome.
3. Load up the page in Firefox.
4. Make a change and see that both browsers refresh.
5. Close Firefox. This will cause Chrome's socket to to be popped off of the `conns` array instead of Firefox's.
6. Make a change and see that Chrome is no longer responding.