### PR TITLE
Update readme and connection settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ If your `brunch watch` is running on a different machine than your preview scree
 You can also set the port (single integer only) and/or disable auto-reload via client-side scripting, although generally it's a better idea to use brunch config for this:
 
 ```js
+window.brunch['auto-reload'] = window.brunch['auto-reload'] || {};
 window.brunch['auto-reload'].port = 1234
 window.brunch['auto-reload'].disabled = true;
 ```

--- a/vendor/auto-reload.js
+++ b/vendor/auto-reload.js
@@ -7,6 +7,7 @@
   if (window._ar) return;
   window._ar = true;
 
+  console.log(ar, br, ar.disabled, !ar.disabled);
   var cacheBuster = function(url) {
     var date = Math.round(Date.now() / 1000).toString();
     url = url.replace(/(\&|\\?)cacheBuster=\d*/, '');

--- a/vendor/auto-reload.js
+++ b/vendor/auto-reload.js
@@ -81,7 +81,6 @@
   var connect = function() {
     var protocol = window.location.protocol == 'https:' ? 'wss://' : 'ws://';
     var connection = new WebSocket(protocol + host + ':' + port);
-    console.log(ar, br, ar.disabled, !ar.disabled);
     connection.onmessage = function(event) {
       var message = event.data;
       var reloader = reloaders[message] || reloaders.page;

--- a/vendor/auto-reload.js
+++ b/vendor/auto-reload.js
@@ -7,7 +7,7 @@
   if (window._ar) return;
   window._ar = true;
 
-  console.log(ar, br, ar.disabled, !ar.disabled);
+  console.log(ar, br, ar.disabled, !ar.disabled, window, window.brunch);
   var cacheBuster = function(url) {
     var date = Math.round(Date.now() / 1000).toString();
     url = url.replace(/(\&|\\?)cacheBuster=\d*/, '');

--- a/vendor/auto-reload.js
+++ b/vendor/auto-reload.js
@@ -84,9 +84,6 @@
     // var connection = new WebSocket(protocol + host + ':' + port);
     // console.log(ar, br, ar.disabled, !ar.disabled);
     console.log(ar, br, ar.disabled, !ar.disabled);
-    if (ar.disabled) {
-      return;
-    };
     var connection = new WebSocket('ws://' + host + ':' + port);
     connection.onmessage = function(event) {
       var message = event.data;

--- a/vendor/auto-reload.js
+++ b/vendor/auto-reload.js
@@ -82,6 +82,7 @@
     var protocol = window.location.protocol == 'https:' ? 'wss://' : 'ws://';
     // var connection = new WebSocket(protocol + host + ':' + port);
     // console.log(ar, br, ar.disabled, !ar.disabled);
+    console.log(ar, br, ar.disabled, !ar.disabled);
     if (ar.disabled) {
       return;
     };

--- a/vendor/auto-reload.js
+++ b/vendor/auto-reload.js
@@ -6,6 +6,7 @@
   if (!WebSocket || ar.disabled) return;
   if (window._ar) return;
   window._ar = true;
+  console.log(ar, br);
 
   var cacheBuster = function(url){
     var date = Math.round(Date.now() / 1000).toString();
@@ -68,7 +69,6 @@
 
   var connect = function(){
     console.log(ar, br);
-
     if (ar.disabled) return;
     var connection = new WebSocket('wss://' + host + ':' + port);
     connection.onmessage = function(event){

--- a/vendor/auto-reload.js
+++ b/vendor/auto-reload.js
@@ -66,9 +66,9 @@
   var host = ar.host || br.server || window.location.hostname || 'localhost';
 
   var connect = function(){
+    if (ar.disabled) return;
     var connection = new WebSocket('ws://' + host + ':' + port);
     connection.onmessage = function(event){
-      if (ar.disabled) return;
       var message = event.data;
       var reloader = reloaders[message] || reloaders.page;
       reloader();

--- a/vendor/auto-reload.js
+++ b/vendor/auto-reload.js
@@ -7,21 +7,21 @@
   if (window._ar) return;
   window._ar = true;
 
-  var cacheBuster = function(url){
+  var cacheBuster = function(url) {
     var date = Math.round(Date.now() / 1000).toString();
     url = url.replace(/(\&|\\?)cacheBuster=\d*/, '');
-    return url + (url.indexOf('?') >= 0 ? '&' : '?') +'cacheBuster=' + date;
+    return url + (url.indexOf('?') >= 0 ? '&' : '?') + 'cacheBuster=' + date;
   };
 
   var browser = navigator.userAgent.toLowerCase();
   var forceRepaint = ar.forceRepaint || browser.indexOf('chrome') > -1;
 
   var reloaders = {
-    page: function(){
+    page: function() {
       window.location.reload(true);
     },
 
-    stylesheet: function(){
+    stylesheet: function() {
       [].slice
         .call(document.querySelectorAll('link[rel=stylesheet]'))
         .filter(function(link) {
@@ -33,20 +33,32 @@
         });
 
       // Hack to force page repaint after 25ms.
-      if (forceRepaint) setTimeout(function() { document.body.offsetHeight; }, 25);
+      if (forceRepaint) {
+        setTimeout(function() {
+          document.body.offsetHeight;
+        }, 25);
+      }
     },
 
-    javascript: function(){
+    javascript: function() {
       var scripts = [].slice.call(document.querySelectorAll('script'));
-      var textScripts = scripts.map(function(script) { return script.text }).filter(function(text) { return text.length > 0 });
-      var srcScripts = scripts.filter(function(script) { return script.src });
+      var textScripts = scripts.map(function(script) {
+        return script.text
+      }).filter(function(text) {
+        return text.length > 0
+      });
+      var srcScripts = scripts.filter(function(script) {
+        return script.src
+      });
 
       var loaded = 0;
       var all = srcScripts.length;
       var onLoad = function() {
         loaded = loaded + 1;
         if (loaded === all) {
-          textScripts.forEach(function(script) { eval(script); });
+          textScripts.forEach(function(script) {
+            eval(script);
+          });
         }
       }
 
@@ -66,25 +78,26 @@
   var port = ar.port || 9485;
   var host = ar.host || br.server || window.location.hostname || 'localhost';
 
-  var connect = function(){
+  var connect = function() {
     var protocol = window.location.protocol == 'https:' ? 'wss://' : 'ws://';
     // var connection = new WebSocket(protocol + host + ':' + port);
+    console.log(ar, br, ar.disabled, !ar.disabled);
+    if (ar.disabled) {
+      return;
+    };
     var connection = new WebSocket('ws://' + host + ':' + port);
-    connection.onmessage = function(event){
+    connection.onmessage = function(event) {
       var message = event.data;
       var reloader = reloaders[message] || reloaders.page;
       reloader();
     };
-    connection.onerror = function(){
+    connection.onerror = function() {
       if (connection.readyState) connection.close();
     };
-    connection.onclose = function(){
+    connection.onclose = function() {
       window.setTimeout(connect, 1000);
     };
   };
-  console.log(ar, br, window.location.protocol);
-  if (!ar.disabled){
-    connect();
-  };
+  connect();
 })();
 /* jshint ignore:end */

--- a/vendor/auto-reload.js
+++ b/vendor/auto-reload.js
@@ -62,10 +62,13 @@
         });
     }
   };
+
   var port = ar.port || 9485;
   var host = ar.host || br.server || window.location.hostname || 'localhost';
 
   var connect = function(){
+    console.log(ar, br);
+
     if (ar.disabled) return;
     var connection = new WebSocket('wss://' + host + ':' + port);
     connection.onmessage = function(event){

--- a/vendor/auto-reload.js
+++ b/vendor/auto-reload.js
@@ -68,7 +68,8 @@
 
   var connect = function(){
     var protocol = window.location.protocol == 'https:' ? 'wss://' : 'ws://';
-    var connection = new WebSocket(protocol + host + ':' + port);
+    // var connection = new WebSocket(protocol + host + ':' + port);
+    var connection = new WebSocket('ws://' + host + ':' + port);
     connection.onmessage = function(event){
       var message = event.data;
       var reloader = reloaders[message] || reloaders.page;

--- a/vendor/auto-reload.js
+++ b/vendor/auto-reload.js
@@ -81,7 +81,7 @@
   var connect = function() {
     var protocol = window.location.protocol == 'https:' ? 'wss://' : 'ws://';
     // var connection = new WebSocket(protocol + host + ':' + port);
-    console.log(ar, br, ar.disabled, !ar.disabled);
+    // console.log(ar, br, ar.disabled, !ar.disabled);
     if (ar.disabled) {
       return;
     };
@@ -98,6 +98,8 @@
       window.setTimeout(connect, 1000);
     };
   };
+  console.log(ar, br, ar.disabled, !ar.disabled);
   connect();
+  console.log(ar, br, ar.disabled, !ar.disabled);
 })();
 /* jshint ignore:end */

--- a/vendor/auto-reload.js
+++ b/vendor/auto-reload.js
@@ -6,7 +6,6 @@
   if (!WebSocket || ar.disabled) return;
   if (window._ar) return;
   window._ar = true;
-  console.log(ar, br);
 
   var cacheBuster = function(url){
     var date = Math.round(Date.now() / 1000).toString();
@@ -68,9 +67,7 @@
   var host = ar.host || br.server || window.location.hostname || 'localhost';
 
   var connect = function(){
-    console.log(ar, br);
-    if (ar.disabled) return;
-    var connection = new WebSocket('wss://' + host + ':' + port);
+    var connection = new WebSocket('ws://' + host + ':' + port);
     connection.onmessage = function(event){
       var message = event.data;
       var reloader = reloaders[message] || reloaders.page;
@@ -83,6 +80,8 @@
       window.setTimeout(connect, 1000);
     };
   };
-  connect();
+  if (!ar.disabled){
+    connect();
+  };
 })();
 /* jshint ignore:end */

--- a/vendor/auto-reload.js
+++ b/vendor/auto-reload.js
@@ -7,7 +7,6 @@
   if (window._ar) return;
   window._ar = true;
 
-  console.log(ar, br, ar.disabled, !ar.disabled, window, window.brunch);
   var cacheBuster = function(url) {
     var date = Math.round(Date.now() / 1000).toString();
     url = url.replace(/(\&|\\?)cacheBuster=\d*/, '');
@@ -81,10 +80,8 @@
 
   var connect = function() {
     var protocol = window.location.protocol == 'https:' ? 'wss://' : 'ws://';
-    // var connection = new WebSocket(protocol + host + ':' + port);
-    // console.log(ar, br, ar.disabled, !ar.disabled);
+    var connection = new WebSocket(protocol + host + ':' + port);
     console.log(ar, br, ar.disabled, !ar.disabled);
-    var connection = new WebSocket('ws://' + host + ':' + port);
     connection.onmessage = function(event) {
       var message = event.data;
       var reloader = reloaders[message] || reloaders.page;
@@ -97,8 +94,8 @@
       window.setTimeout(connect, 1000);
     };
   };
-  console.log(ar, br, ar.disabled, !ar.disabled);
-  connect();
-  console.log(ar, br, ar.disabled, !ar.disabled);
+  if(ar.disabled == undefined || !ar.disabled){
+    connect();
+  }
 })();
 /* jshint ignore:end */

--- a/vendor/auto-reload.js
+++ b/vendor/auto-reload.js
@@ -67,7 +67,7 @@
 
   var connect = function(){
     if (ar.disabled) return;
-    var connection = new WebSocket('ws://' + host + ':' + port);
+    var connection = new WebSocket('wss://' + host + ':' + port);
     connection.onmessage = function(event){
       var message = event.data;
       var reloader = reloaders[message] || reloaders.page;

--- a/vendor/auto-reload.js
+++ b/vendor/auto-reload.js
@@ -7,21 +7,21 @@
   if (window._ar) return;
   window._ar = true;
 
-  var cacheBuster = function(url) {
+  var cacheBuster = function(url){
     var date = Math.round(Date.now() / 1000).toString();
     url = url.replace(/(\&|\\?)cacheBuster=\d*/, '');
-    return url + (url.indexOf('?') >= 0 ? '&' : '?') + 'cacheBuster=' + date;
+    return url + (url.indexOf('?') >= 0 ? '&' : '?') +'cacheBuster=' + date;
   };
 
   var browser = navigator.userAgent.toLowerCase();
   var forceRepaint = ar.forceRepaint || browser.indexOf('chrome') > -1;
 
   var reloaders = {
-    page: function() {
+    page: function(){
       window.location.reload(true);
     },
 
-    stylesheet: function() {
+    stylesheet: function(){
       [].slice
         .call(document.querySelectorAll('link[rel=stylesheet]'))
         .filter(function(link) {
@@ -33,32 +33,20 @@
         });
 
       // Hack to force page repaint after 25ms.
-      if (forceRepaint) {
-        setTimeout(function() {
-          document.body.offsetHeight;
-        }, 25);
-      }
+      if (forceRepaint) setTimeout(function() { document.body.offsetHeight; }, 25);
     },
 
-    javascript: function() {
+    javascript: function(){
       var scripts = [].slice.call(document.querySelectorAll('script'));
-      var textScripts = scripts.map(function(script) {
-        return script.text
-      }).filter(function(text) {
-        return text.length > 0
-      });
-      var srcScripts = scripts.filter(function(script) {
-        return script.src
-      });
+      var textScripts = scripts.map(function(script) { return script.text }).filter(function(text) { return text.length > 0 });
+      var srcScripts = scripts.filter(function(script) { return script.src });
 
       var loaded = 0;
       var all = srcScripts.length;
       var onLoad = function() {
         loaded = loaded + 1;
         if (loaded === all) {
-          textScripts.forEach(function(script) {
-            eval(script);
-          });
+          textScripts.forEach(function(script) { eval(script); });
         }
       }
 
@@ -78,7 +66,7 @@
   var port = ar.port || 9485;
   var host = ar.host || br.server || window.location.hostname || 'localhost';
 
-  var connect = function() {
+  var connect = function(){
     var protocol = window.location.protocol == 'https:' ? 'wss://' : 'ws://';
     var connection = new WebSocket(protocol + host + ':' + port);
     connection.onmessage = function(event) {
@@ -86,10 +74,10 @@
       var reloader = reloaders[message] || reloaders.page;
       reloader();
     };
-    connection.onerror = function() {
+    connection.onerror = function(){
       if (connection.readyState) connection.close();
     };
-    connection.onclose = function() {
+    connection.onclose = function(){
       window.setTimeout(connect, 1000);
     };
   };

--- a/vendor/auto-reload.js
+++ b/vendor/auto-reload.js
@@ -67,7 +67,8 @@
   var host = ar.host || br.server || window.location.hostname || 'localhost';
 
   var connect = function(){
-    var connection = new WebSocket('ws://' + host + ':' + port);
+    var protocol = window.location.protocol == 'https:' ? 'wss://' : 'ws://';
+    var connection = new WebSocket(protocol + host + ':' + port);
     connection.onmessage = function(event){
       var message = event.data;
       var reloader = reloaders[message] || reloaders.page;
@@ -80,6 +81,7 @@
       window.setTimeout(connect, 1000);
     };
   };
+  console.log(ar, br, window.location.protocol);
   if (!ar.disabled){
     connect();
   };


### PR DESCRIPTION
I noticed a problem with how the docs recommend to attach the front-end settings:

```
<script>
    window.brunch = window.brunch || {};
    window.brunch['auto-reload'].disabled = true;
</script>
```

Results in "Can not set the property "disabled" of undefined.

```
<script>
    window.brunch = window.brunch || {};
    window.brunch['auto-reload'] = window.brunch['auto-reload'] || {};
    window.brunch['auto-reload'].disabled = true;
</script>
```

The program works as expected when I create the auto-reload object on the brunch object first.

I've also modified the connect() function in the front-end code.

The function should check first if auto-reload is enabled before creating the Websocket call.

Finally I added a check for https / http. The Websocket will not work unless it is wss from https and vice versa. So it's a fair assumption that if the page is running at https: then the Websocket will connect at wss.

Hope this gets merged! Let me know if you have any questions or concerns.